### PR TITLE
[fix] Include source files in output artifact

### DIFF
--- a/publishing.gradle
+++ b/publishing.gradle
@@ -7,7 +7,7 @@ version Publishing.VERSION
 
 task sourcesJar(type: Jar) {
     classifier = 'sources'
-    from android.sourceSets.main.java.sourceFiles
+    from android.sourceSets.main.java.srcDirs
 }
 
 publishing {


### PR DESCRIPTION
The sources were not being included properly due to a misconfiguration in the sourcesJar gradle task (part of publishing).

Tested by publishing to mavenLocal and verified the sources are now included.