### PR TITLE
Prep for 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Varanus releases
 
+# Version 3.0.0
+* Bump OkHTTP to 4.5.0
+* Bump Java to 1.8
+
 # Version 2.0.2
 * First official public Varanus release 

--- a/buildSrc/src/main/java/com/yelp/gradle/varanus/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/com/yelp/gradle/varanus/GlobalDependencies.kt
@@ -80,6 +80,6 @@ object BuildScriptLibs {
 
 object Publishing {
     const val GROUP = "com.yelp.android"
-    const val VERSION = "2.0.5"
+    const val VERSION = "3.0.0"
 }
 


### PR DESCRIPTION
Has to be a major version bump because consuming apps must now use java 1.8